### PR TITLE
feat: enabled error handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
   "ignorePatterns": ["dist", "node_modules"],
   "rules": {
     "@typescript-eslint/consistent-type-imports": "warn",
-    "prettier/prettier": "warn"
+    "prettier/prettier": "warn",
+    "@typescript-eslint/no-unsafe-member-access": "off"
   }
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -60,7 +60,7 @@ class App {
   // initialize routes
   private initializeRoutes: IInitializeRoutes = (routes) => {
     routes.forEach((route) => {
-      this.express.use('api/v1', route.router);
+      this.express.use('/api/v1', route.router);
     });
   };
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -3,14 +3,15 @@ import type {
   IReturnsVoid,
 } from '@/interfaces/app.interface';
 import type IRoute from '@/interfaces/route.interface';
-import compression from 'compression';
-import cors from 'cors';
 import type { Application } from 'express';
 
+import compression from 'compression';
+import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import mongoose from 'mongoose';
 import morgan from 'morgan';
+import errorHandler from './middlewares/errorHandling.middleware';
 import routeNotFoundHandler from './middlewares/notFound.middleware';
 
 class App {
@@ -26,6 +27,7 @@ class App {
     this.initializeMiddlewares();
     this.initializeRoutes(routes);
     this.enableUnknownRouteHandling();
+    this.enableErrorHandling();
   }
   // initialize database
   private initializeDatabaseConnection: IReturnsVoid = () => {
@@ -68,6 +70,9 @@ class App {
   };
 
   //todo: enable error handling
+  private enableErrorHandling: IReturnsVoid = () => {
+    this.express.use(errorHandler);
+  };
 
   // listen to server
   public listen: IReturnsVoid = () => {

--- a/src/middlewares/errorHandling.middleware.ts
+++ b/src/middlewares/errorHandling.middleware.ts
@@ -1,0 +1,9 @@
+import type { ErrorRequestHandler } from 'express';
+
+const errorHandler: ErrorRequestHandler = (err, req, res) => {
+  const status = Number(err?.status ?? 500);
+  const message = String(err?.message) ?? `Something went wrong`;
+  res.status(status).json({ message });
+};
+
+export default errorHandler;

--- a/src/middlewares/notFound.middleware.ts
+++ b/src/middlewares/notFound.middleware.ts
@@ -1,8 +1,8 @@
-import type { Request, RequestHandler, Response } from 'express';
+import type { RequestHandler } from 'express';
 
-const routeNotFoundHandler: RequestHandler = (req: Request, res: Response) => {
+const routeNotFoundHandler: RequestHandler = (req, res) => {
   res.status(404).json({
-    message: 'Route not found',
+    message: 'Route does not exist',
   });
 };
 

--- a/src/utils/exceptions/errors/badRequest.error.ts
+++ b/src/utils/exceptions/errors/badRequest.error.ts
@@ -1,0 +1,9 @@
+import HttpException from '@/utils/exceptions/http.exception';
+
+class BadRequestError extends HttpException {
+  constructor(message = 'Its a bad request') {
+    super(400, message);
+  }
+}
+
+export default BadRequestError;

--- a/src/utils/exceptions/errors/forbidden.error.ts
+++ b/src/utils/exceptions/errors/forbidden.error.ts
@@ -1,0 +1,9 @@
+import HttpException from '@/utils/exceptions/http.exception';
+
+class ForbiddenError extends HttpException {
+  constructor(message = `Don't have permission to access`) {
+    super(400, message);
+  }
+}
+
+export default ForbiddenError;

--- a/src/utils/exceptions/errors/index.ts
+++ b/src/utils/exceptions/errors/index.ts
@@ -1,0 +1,11 @@
+import BadRequestError from '@/utils/exceptions/errors/badRequest.error';
+import ForbiddenError from '@/utils/exceptions/errors/forbidden.error';
+import NotFoundError from '@/utils/exceptions/errors/notFound.error';
+
+const Errors = {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+};
+
+export default Errors;

--- a/src/utils/exceptions/errors/notFound.error.ts
+++ b/src/utils/exceptions/errors/notFound.error.ts
@@ -1,0 +1,9 @@
+import HttpException from '@/utils/exceptions/http.exception';
+
+class NotFoundError extends HttpException {
+  constructor(message = 'Item not found') {
+    super(400, message);
+  }
+}
+
+export default NotFoundError;

--- a/src/utils/exceptions/http.exception.ts
+++ b/src/utils/exceptions/http.exception.ts
@@ -1,0 +1,11 @@
+class HttpException extends Error {
+  public status: number;
+  public message: string;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.message = message;
+  }
+}
+
+export default HttpException;


### PR DESCRIPTION
This PR enables error handling to the application.
- Implemented default express route handling
- Handler **async** express errors as well
- It captures all errors that may occur in the run time
- This error handler handles normal exceptions like bad request, not found etc, which are an instance of **http** exceptions.
- If the error is not an instance of **HttpException** then `500` is thrown as a response

closes #3 
closes #4  